### PR TITLE
Fixed bug in joule.api.Event.__eq__

### DIFF
--- a/src/joule/api/data.py
+++ b/src/joule/api/data.py
@@ -360,7 +360,7 @@ async def _read_nilmdb_data(nilmdb_url, stream, start, end, max_rows, flatten) -
             while not resp.content.at_eof() and len(data)<=max_bytes:
                 data += await resp.content.read(max_bytes)
             if not resp.content.at_eof():
-                print(f"WARNING: Requested time interval mas more data than {max_rows} rows of data")
+                print(f"WARNING: Requested time interval has more data than {max_rows} rows of data")
     sdata = np.frombuffer(data[:max_bytes], dtype=dtype)
     if flatten:
         return np.c_[sdata['timestamp'][:, None], sdata['data']]

--- a/src/joule/api/event.py
+++ b/src/joule/api/event.py
@@ -32,11 +32,11 @@ class Event:
             self.start_time, self.end_time, content_str)
 
     def __eq__(self, other):
-        if other.start_time != other.start_time:
+        if self.start_time != other.start_time:
             return False
-        if other.end_time != other.end_time:
+        if self.end_time != other.end_time:
             return False
-        if json.dumps(other.content) != json.dumps(other.content):
+        if json.dumps(self.content) != json.dumps(other.content):
             return False
         return True
 

--- a/tests/api/test_event_api.py
+++ b/tests/api/test_event_api.py
@@ -21,6 +21,10 @@ class TestEventApi(unittest.IsolatedAsyncioTestCase):
         self.session = mock_session.MockSession()
         self.node.session = self.session
 
+    async def test_event_equality(self):
+        self.assertNotEqual(Event(0, 1, content={'a': 'b'}), Event(10, 11, content={'b': 'c'}))
+        self.assertEqual(Event(20, 30, content={'a': 'b'}), Event(20, 30, content={'a': 'b'}))
+
     async def test_deletes_event_streams(self):
         # can delete by ID
         await self.node.event_stream_delete(1)


### PR DESCRIPTION
It appears that currently the Event API class's equality operator always returns True because the conditions for False are never actually tested between "self" and "other" - instead they're tested between "other" and "other". I'm guessing this was a typo originally, and I've changed it to what I imagine the original intent was. I've also added a test case in tests.api.test_event_api.